### PR TITLE
Fix clientside component loading, add/update WorldObjects

### DIFF
--- a/WorldSmith/WorldSmithClientUtilities.lua
+++ b/WorldSmith/WorldSmithClientUtilities.lua
@@ -1,10 +1,43 @@
+local ContextActionService = game:GetService("ContextActionService")
+
 local WorldSmithUtilities = {}
 
 local clientSideActiveWorldObjects = {}
 local clientSideAssignedWorldObjects = {}
 
-function WorldSmithUtilities.AnimatedDoor(parameters, dir, worldObjectRef)
-	if not clientSideActiveWorldObjects[worldObjectRef] then
+WorldSmithUtilities.inVehicle = false
+
+function WorldSmithUtilities.YieldUntilComponentLoaded(component)
+	while true do
+		local numChildren = #component:GetChildren()
+		if numChildren > 0 then
+			break
+		end
+		game:GetService("RunService").Heartbeat:wait()
+	end
+end
+
+function WorldSmithUtilities.CreateArgDictionary(paramContainerChildren)
+	local t = {}
+	local c = paramContainerChildren
+	for i, v in ipairs(c) do
+		if v:IsA("ValueBase") then
+			t[v.Name] = v.Value
+		end
+	end
+	return t
+end
+
+function WorldSmithUtilities.QueryWorldObject(worldObjectRef, param)
+	if worldObjectRef[param] then
+		return worldObjectRef[param].Value
+	else
+		error("WorldObject '".. worldObjectRef.Name .. "' does not have parameter '" .. param .. "'")
+	end
+end
+
+function WorldSmithUtilities.AnimatedDoor(parameters, dir, worldObjectRef, player)
+	if not clientSideActiveWorldObjects[worldObjectRef] and player ~= game.Players.LocalPlayer then
 		clientSideActiveWorldObjects[worldObjectRef] = true
 		local cf1 = parameters.PivotPart.CFrame * CFrame.Angles(0, dir * (math.pi / 2), 0)
 		local tween1 = game:GetService("TweenService"):Create(
@@ -26,23 +59,120 @@ function WorldSmithUtilities.AnimatedDoor(parameters, dir, worldObjectRef)
 	end
 end
 
-function WorldSmithUtilities.CreateArgDictionary(paramContainerChildren)
-	local t = {}
-	local c = paramContainerChildren
-	for i, v in ipairs(c) do
-		if v:IsA("ValueBase") then
-			t[v.Name] = v.Value
+function WorldSmithUtilities.Vehicle(parameters, argType, worldObjectRef)
+	local currentRot = 0
+	local currentVelocity = 0
+	local bodyVelocity = worldObjectRef.MainPart.Value.BodyVelocity --Instance.new("BodyVelocity", worldObjectRef.MainPart.Value)
+	local bodyGyro = worldObjectRef.MainPart.Value.BodyGyro--Instance.new("BodyGyro", worldObjectRef.MainPart.Value)
+	if argType == "enterVehicle" then
+		WorldSmithUtilities.inVehicle = true
+		game.Players.LocalPlayer.Character.Humanoid:SetStateEnabled(Enum.HumanoidStateType.Physics, true)
+		game.Players.LocalPlayer.Character.Humanoid:ChangeState(Enum.HumanoidStateType.Physics)
+		ContextActionService:BindAction(
+			"ExitVehicle",
+			function(actionName, inputState, inputObj)
+				if inputState == Enum.UserInputState.Begin then
+					game.Players.LocalPlayer.Character.Humanoid:SetStateEnabled(Enum.HumanoidStateType.GettingUp, true)
+					game.Players.LocalPlayer.Character.Humanoid:ChangeState(Enum.HumanoidStateType.GettingUp)
+					game.Players.LocalPlayer.Character.HumanoidRootPart:FindFirstChild("Weld"):Destroy()
+					ContextActionService:UnbindAction("ExitVehicle")
+					ContextActionService:UnbindAction("Throttle")
+					ContextActionService:UnbindAction("Reverse")
+					ContextActionService:UnbindAction("Left")
+					ContextActionService:UnbindAction("Right")
+					WorldSmithUtilities.inVehicle = false
+					worldObjectRef.RemoteEvent:FireServer("exitVehicle")
+				end
+			end, 
+			true, 
+			Enum[worldObjectRef.EnterTrigger.Value.InputEnum.Value][worldObjectRef.EnterTrigger.Value.InputType.Value]
+		)
+		ContextActionService:BindAction(
+			"Throttle",
+			function(actionName, inputState, inputObj)
+				while wait() do
+					local addedVelocity = currentVelocity + parameters.AccelerationRate <= parameters.MaxSpeed and parameters.AccelerationRate or 0
+					if inputObj.UserInputState ~= Enum.UserInputState.Begin or not WorldSmithUtilities.inVehicle then 
+						break 
+					end
+					bodyVelocity.MaxForce = Vector3.new(1, 0, 1) * parameters.MaxForce
+					currentVelocity = currentVelocity + addedVelocity
+				end
+			end,
+			false,
+			Enum.KeyCode.W
+		)
+		ContextActionService:BindAction(
+			"Reverse",
+			function(actionName, inputState, inputObj)
+				while wait() do
+					local addedVelocity = math.abs(currentVelocity - parameters.AccelerationRate) <= parameters.MaxSpeed and parameters.AccelerationRate or 0
+					if inputObj.UserInputState ~= Enum.UserInputState.Begin or not WorldSmithUtilities.inVehicle then 
+						break 
+					end
+					bodyVelocity.MaxForce = Vector3.new(1, 0, 1) * parameters.MaxForce
+					currentVelocity = currentVelocity - addedVelocity
+				end
+			end,
+			false,
+			Enum.KeyCode.S
+		)
+		ContextActionService:BindAction(
+			"Left",
+			function(actionName, inputState, inputObj)
+				while wait() do
+					local addedRot = math.abs(currentRot - parameters.TurnRate) <= parameters.MaxTurnSpeed and parameters.TurnRate or 0
+					if inputObj.UserInputState ~= Enum.UserInputState.Begin or not WorldSmithUtilities.inVehicle then
+						currentRot = 0
+						break 
+					end
+					if math.abs(currentVelocity) > 0.1 then
+						bodyGyro.CFrame = CFrame.fromMatrix(worldObjectRef.MainPart.Value.CFrame.p, -worldObjectRef.MainPart.Value.CFrame.RightVector, Vector3.new(0, 1, 0), -worldObjectRef.MainPart.Value.CFrame.LookVector) * CFrame.Angles(0, math.rad(-(currentRot + addedRot)), 0)
+						currentRot = currentRot + addedRot
+						bodyGyro.MaxTorque = Vector3.new(1, 1, 1) * parameters.MaxForce
+					else
+						bodyGyro.MaxTorque = Vector3.new(0, 0, 0)
+						currentRot = 0
+					end
+				end
+			end,
+			false,
+			Enum.KeyCode.A
+		)
+		ContextActionService:BindAction(
+			"Right",
+			function(actionName, inputState, inputObj)
+				while wait() do
+					local addedRot = math.abs(currentRot + parameters.TurnRate) <= parameters.MaxTurnSpeed and parameters.TurnRate or 0
+					if inputObj.UserInputState ~= Enum.UserInputState.Begin or not WorldSmithUtilities.inVehicle then
+						currentRot = 0
+						break 
+					end
+					if math.abs(currentVelocity) > 0.1 then
+						bodyGyro.CFrame = CFrame.fromMatrix(worldObjectRef.MainPart.Value.CFrame.p, -worldObjectRef.MainPart.Value.CFrame.RightVector, Vector3.new(0, 1, 0), -worldObjectRef.MainPart.Value.CFrame.LookVector) * CFrame.Angles(0, math.rad(currentRot + addedRot), 0)
+						currentRot = currentRot + addedRot
+						bodyGyro.MaxTorque = Vector3.new(1, 1, 1) * parameters.MaxForce
+					else
+						bodyGyro.MaxTorque = Vector3.new(0, 0, 0)
+						currentRot = 0
+					end
+				end
+			end,
+			false,
+			Enum.KeyCode.D
+		)
+	end
+	spawn(function() 
+		while (WorldSmithUtilities.inVehicle or math.abs(currentVelocity) > 0) do
+			if math.abs(currentVelocity) > parameters.BrakeDeceleration * 2 then
+				currentVelocity = currentVelocity > 0 and currentVelocity - parameters.BrakeDeceleration or currentVelocity + parameters.BrakeDeceleration
+			else
+				currentVelocity = 0
+			end
+			bodyVelocity.Velocity = worldObjectRef.MainPart.Value.CFrame.LookVector.unit * (currentVelocity)
+			wait()
 		end
-	end
-	return t
-end
-
-function WorldSmithUtilities.QueryWorldObject(worldObjectRef, param)
-	if worldObjectRef[param] then
-		return worldObjectRef[param].Value
-	else
-		error("WorldObject '".. worldObjectRef.Name .. "' does not have parameter '" .. param .. "'")
-	end
+	end)
 end
 
 return WorldSmithUtilities

--- a/WorldSmith/WorldSmithServerMain.lua
+++ b/WorldSmith/WorldSmithServerMain.lua
@@ -11,6 +11,7 @@ function WorldSmithMain.new()
 	local self = setmetatable({}, WorldSmithMain)
 	
 	self:_buildEntityComponentMap()
+	self._registeredSystems = {}
 	
 	for entity, componentList in pairs(self._entityComponentMap) do
 		for _, component in ipairs(componentList) do
@@ -26,14 +27,14 @@ function WorldSmithMain.new()
 	end)
 	
 	CollectionService:GetInstanceAddedSignal("component"):connect(function(component)
-		print('added component' .. component.Name)
 		if not self._registeredSystems[component] then
 			self._registeredSystems[component] = true
 			if self._entityComponentMap[component.Parent] then
 				self._entityComponentMap[component.Parent][#self._entityComponentMap[component.Parent] + 1] = component
+				WorldSmithUtilities.YieldUntilComponentLoaded(component)
 				local paramContainerChildren = component:GetChildren()
-				if WorldObjectInfo[component.Name]._init ~= nil then
-					WorldObjectInfo[component.Name].init(WorldSmithUtilities.CreateArgDictionary(paramContainerChildren), component)
+				if WorldObjectInfo[component.Name]._init ~= nil and not component.Parent:FindFirstChild("CLONE") then
+					WorldObjectInfo[component.Name]._init(WorldSmithUtilities.CreateArgDictionary(paramContainerChildren), component)
 				end
 				if WorldObjectInfo[component.Name]._connectEventsFunction ~= nil then
 					WorldObjectInfo[component.Name]._connectEventsFunction(WorldSmithUtilities.CreateArgDictionary(paramContainerChildren), component)

--- a/WorldSmith/WorldSmithServerUtilities.lua
+++ b/WorldSmith/WorldSmithServerUtilities.lua
@@ -2,6 +2,16 @@ local WorldObject = require(script.Parent.WorldObject)
 
 local WorldSmithUtilities = {}
 
+
+function WorldSmithUtilities.YieldUntilComponentLoaded(component)
+	while true do
+		local numChildren = #component:GetChildren()
+		if numChildren > 0 then
+			break
+		end
+		game:GetService("RunService").Heartbeat:wait()
+	end
+end
 function WorldSmithUtilities.CreateTouchTrigger(cframe, size, container, triggerName, initFunction)
 	local trigger = Instance.new("Part")
 	trigger.Size = size
@@ -30,6 +40,37 @@ function WorldSmithUtilities.AnimateDoor(parameters, dir, remoteEvent, player, c
 		container.Enabled.Value = true
 	end
 end
+function WorldSmithUtilities.CreateArgDictionary(paramContainerChildren)
+	local t = {}
+	local c = paramContainerChildren
+	for i, v in ipairs(c) do
+		if v:IsA("ValueBase") then
+			t[v.Name] = v.Value
+		end
+	end
+	return t
+end
+
+function WorldSmithUtilities.Vehicle(parameters, argType, remoteEvent, player, container)
+	if argType == "enterVehicle" then
+		local motor6d = Instance.new("Weld")
+		player.Character.Humanoid:SetStateEnabled(Enum.HumanoidStateType.Physics, true)
+		player.Character.Humanoid:ChangeState(Enum.HumanoidStateType.Physics)
+		player.Character.HumanoidRootPart.CFrame = parameters.DriverConstraint.Parent.CFrame
+		container.MainPart.Value:SetNetworkOwner(player)
+		motor6d.Part0 = player.Character.HumanoidRootPart
+		motor6d.Part1 = parameters.DriverConstraint.Parent
+		motor6d.Parent = player.Character.HumanoidRootPart
+		remoteEvent:FireClient(player, player, WorldSmithUtilities.CreateArgDictionary(container:GetChildren()), argType)
+	elseif argType == "exitVehicle" then
+		player.Character.Humanoid:SetStateEnabled(Enum.HumanoidStateType.GettingUp, true)
+		player.Character.Humanoid:ChangeState(Enum.HumanoidStateType.GettingUp)
+		container.EnterTrigger.Value.Enabled.Value = true
+		parameters._totalOccupants = parameters._totalOccupants - 1
+		repeat wait() until container.MainPart.Value.Velocity.magnitude < 0.1
+		container.MainPart.Value:SetNetworkOwner(nil)
+	end
+end
 
 function WorldSmithUtilities.ConstrainCharacter(player, container)
 	player.Character.Humanoid:SetStateEnabled(Enum.HumanoidStateType.Physics, true)
@@ -42,17 +83,6 @@ function WorldSmithUtilities.GetTriggerEventNames(triggerObj)
 	local objName = (triggerObj:FindFirstChild("Event") and "Event") or (triggerObj:FindFirstChild("RemoteEvent") and "RemoteEvent")
 	local eventName = (triggerObj:FindFirstChild("Event") and "Event") or (triggerObj:FindFirstChild("RemoteEvent") and "OnServerEvent")
 	return objName, eventName
-end
-
-function WorldSmithUtilities.CreateArgDictionary(paramContainerChildren)
-	local t = {}
-	local c = paramContainerChildren
-	for i, v in ipairs(c) do
-		if v:IsA("ValueBase") then
-			t[v.Name] = v.Value
-		end
-	end
-	return t
 end
 
 return WorldSmithUtilities

--- a/WorldSmithSource.lua
+++ b/WorldSmithSource.lua
@@ -95,7 +95,7 @@ main = function()
 	spawn(function()
 		while wait(0.5) do
 			if DockWidgetPluginGui.Parent ~= nil then
-				if not game.ServerScriptService:WaitForChild("WorldSmith", 2) then
+				if not game.ServerScriptService:WaitForChild("WorldSmith", 0.5) then
 					local bin = script.Parent.WorldSmith:Clone()
 					bin.Parent = game.ServerScriptService	
 				end
@@ -109,12 +109,12 @@ main = function()
 	spawn(function() 
 		while wait(0.5) do
 			if DockWidgetPluginGui.Parent ~= nil then
-				if not game.ReplicatedStorage:WaitForChild("WorldSmith", 2) then
+				if not game.ReplicatedStorage:WaitForChild("WorldSmith", 0.5) then
 					local bin = Instance.new("Folder")
 					bin.Name = "WorldSmith"
 					bin.Parent = game.ReplicatedStorage	
-					game.ServerScriptService.WorldSmith.WorldSmithClientMain:Clone().Parent = bin
-					game.ServerScriptService.WorldSmith.WorldSmithClientUtilities:Clone().Parent = bin
+					script.Parent.WorldSmith.WorldSmithClientMain:Clone().Parent = bin
+					script.Parent.WorldSmith.WorldSmithClientUtilities:Clone().Parent = bin
 				end
 			else
 				break
@@ -283,7 +283,7 @@ main = function()
 			if paramContainer then
 				for _, parameter in pairs(paramContainer:GetChildren()) do
 					if parameter:IsA("ObjectValue") then
-						createInstanceParameterInput(parameter.Name, setParams, parameterList, parameter.Value.Name)
+						createInstanceParameterInput(parameter.Name, setParams, parameterList, parameter.Value.Name or "")
 						setParams[parameter.Name] = parameter.Value
 					elseif parameter:IsA("NumberValue") then
 						createNumberParameterInput(parameter.Name, setParams, parameterList, tonumber(parameter.Value))
@@ -339,10 +339,12 @@ main = function()
 	end)
 	
 	RefreshWorldObjects.Click:connect(function()
-		local newWorldObjects = game.ServerScriptService.WorldSmith.WorldObjectInfo:Clone()
-		game.ServerScriptService.WorldSmith.WorldObjectInfo:Destroy()
-		newWorldObjects.Parent = game.ServerScriptService.WorldSmith
-		WorldObjectInfo = require(newWorldObjects)
+		if game.ReplicatedStorage:FindFirstChild("WorldSmith") then
+			game.ReplicatedStorage.WorldSmith:Destroy()
+		end
+		if game.ServerScriptService:FindFirstChild("WorldSmith") then
+			game.ServerScriptService.WorldSmith:Destroy()
+		end
 	end)
 	
 	Settings.Click:connect(function()


### PR DESCRIPTION
Add WorldSmithClientUtilities.YieldUntilComponentLoaded(component)

Update WorldSmithClientMain.clientPredictionFunc.ContextActionTrigger

Remove WorldSmithClientMain.clientPredictionFunc.Vehicle

Add
WorldSmithClientUtilities.Vehicle(parameters, argType, worldObjectRef)

Add
WorldSmithServerUtilities.YieldUntilComponentLoaded(component)

Add
WorldSmithServerUtilities.Vehicle(parameters, argType, remoteEvent, player, container)

Add WorldObjectInfo.Respawner

Update WorldObjectInfo.Vehicle

Fix autoloading of dependencies